### PR TITLE
Freischaltung der Gruppe erst wenn Bestellung bezahlt wurde

### DIFF
--- a/contao/config/config.php
+++ b/contao/config/config.php
@@ -6,6 +6,6 @@ declare(strict_types=1);
  * This file is part of the ContaoIsotopeProductMemberGroups extension.
  */
 
-use Fenepedia\ContaoIsotopeProductMemberGroups\EventListener\Isotope\PostCheckout\AddMemberGroupsListener;
+use Fenepedia\ContaoIsotopeProductMemberGroups\EventListener\Isotope\PostOrderStatusUpdate\AddMemberGroupsListener;
 
-$GLOBALS['ISO_HOOKS']['postCheckout'][] = [AddMemberGroupsListener::class, '__invoke'];
+$GLOBALS['ISO_HOOKS']['postOrderStatusUpdate'][] = [AddMemberGroupsListener::class, '__invoke'];

--- a/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
+++ b/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
@@ -30,7 +30,7 @@ class AddMemberGroupsListener
             return;
         }
 
-        if (($memberId = $order->member) <= 0) {
+        if (!$order->member) {
             return;
         }
 

--- a/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
+++ b/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
@@ -34,7 +34,10 @@ class AddMemberGroupsListener
             return;
         }
 
-        $member = MemberModel::findByPk($memberId);
+        if (!$member = MemberModel::findByPk($order->member)) {
+            return;
+        }
+
         if (!($addGroups = $this->getMemberGroups($order))) {
             return;
         }

--- a/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
+++ b/src/EventListener/Isotope/PostOrderStatusUpdate/AddMemberGroupsListener.php
@@ -53,6 +53,7 @@ class AddMemberGroupsListener
             $allGroups = [...$allGroups, ...self::processGroups($product->addMemberGroups)];
             $allGroups = [...$allGroups, ...self::processGroups($product->getType()->addMemberGroups)];
         }
+
         return array_unique($allGroups);
     }
 


### PR DESCRIPTION
Umstieg auf den Hook postOrderStatusUpdate um alle Bestellungen zu berücksichtigen, egal ob der Status "bezahlt"  bereits im Zuge der Bestellung automatisch oder später manuell im Backend gesetzt wurde.

Siehe Ticket #2